### PR TITLE
Fix the out-of-bound bug

### DIFF
--- a/c++/src/configuration.cpp
+++ b/c++/src/configuration.cpp
@@ -79,6 +79,10 @@ Configuration::Configuration(std::vector<std::vector<double> > const & coordinat
 void Configuration::initMatchLists( const LatticeMap & lattice_map,
                                     const int range )
 {
+    // Store the max size of minimal_match_list_
+    size_t max_size = 0;
+    size_t tmp_size;
+
     // Loop over all lattice sites.
     for (size_t i = 0; i < types_.size(); ++i)
     {
@@ -88,13 +92,19 @@ void Configuration::initMatchLists( const LatticeMap & lattice_map,
         match_lists_[i] = minimalMatchList(origin_index,
                                            neighbourhood,
                                            lattice_map);
+
+        // Store the maximum size
+        tmp_size = match_lists_[i].size();
+        if ( tmp_size > max_size )
+        {
+            max_size = tmp_size;
+        }
     }
 
     // Now that we know the size of the match lists we can allocate
     // memory for the moved_atom_ids_ vector.
-    const size_t size = match_lists_[0].size();
-    moved_atom_ids_.resize(size);
-    recent_move_vectors_.resize(size);
+    moved_atom_ids_.resize(max_size);
+    recent_move_vectors_.resize(max_size);
 }
 
 

--- a/c++/unittest/test_configuration.h
+++ b/c++/unittest/test_configuration.h
@@ -25,6 +25,7 @@ public:
 
     CPPUNIT_TEST_SUITE( Test_Configuration );
     CPPUNIT_TEST( testConstruction );
+    CPPUNIT_TEST( testMovedAtomIDsRecentMoveVectorsSize );
     CPPUNIT_TEST( testPerformProcess );
     CPPUNIT_TEST( testPerformProcessVectors );
     CPPUNIT_TEST( testAtomID );
@@ -34,6 +35,7 @@ public:
     CPPUNIT_TEST_SUITE_END();
 
     void testConstruction();
+    void testMovedAtomIDsRecentMoveVectorsSize();
     void testPerformProcess();
     void testPerformProcessVectors();
     void testAtomID();


### PR DESCRIPTION
Hi, Leetmaa,

I have found that there may be a out-of-bound risk in `Configuration::initMatchLists()` function.

You used the size of first of minimal match list in match lists to allocate the memories for `moved_atom_ids_` and `recent_moved_vectors_`. But if the periodic of lattice map is not `{true, true, ture}`, the size of first minimal match list may smaller than that of minimal match list in the middle of lattice. Take a 3x3x3 lattice for example, the neighbor number of site0 is 8, but the number of neighbors of site 13 is 27, but the initial size of those two poor vectors are both 8 at first. 
So there may be a risk of out-of -bound, using the maximum size of all minimal match list is better way i think.

I also add a new test function in unit test to make sure the sizes of those two vectors are safe. If using the first size, the test will be failed.

Thanks.
ShaoZhengjiang