### PR TITLE
Fix bug in external/Makefile

### DIFF
--- a/c++/externals/Makefile
+++ b/c++/externals/Makefile
@@ -64,7 +64,7 @@ cppunit: ./src/cppunit-1.12.1/INSTALL_STAMP
 	make && \
 	make check && \
 	make install && \
-	cp ./src/cppunit/.libs/libcppunit* ../../lib/cppunit/lib/
+	cp ./src/cppunit/.libs/libcppunit* ../../lib/cppunit/lib/ && \
 	touch BUILD_STAMP && \
 	cd -
 
@@ -101,7 +101,7 @@ cppunit: ./src/cppunit-1.12.1/INSTALL_STAMP
 clean:
 	rm -r ./src/cppunit-1.12.1/ && \
 	rm -r ./src/md5/ && \
-	rm ./include/externals/*.h &&\
+	rm ./include/externals/*.h && \
 	rm -r ./include/cppunit && \
 	rm -r ./lib/cppunit/ && \
 	rm ./obj/*.o


### PR DESCRIPTION
Dear Leetmaa,

I get an Make Error when building cppunit in externals. 
```
/bin/sh: line1 cd: OLDPWD not set
make *** [src/cppunit-1.12.1/BUILD_STAMP] Error 1
``` 
Then i check the Makefile in c++/externals and find you might forget the line separator when generating the /cppunit-1.12.1/BUILD_STAMP
So I add a new separator and fix this building problem  :)

Shao Zhengjiang