### PR TITLE
Fix bug in sortCoordinatesDistance() utility function

### DIFF
--- a/python/src/KMCLib/Utilities/CoordinateUtilities.py
+++ b/python/src/KMCLib/Utilities/CoordinateUtilities.py
@@ -68,7 +68,7 @@ def sortCoordinatesDistance(coordinates, center, types1, types2=None, co_sort=No
 
     # Calculate the distance form the center.
     origin = coordinates[center]
-    distances = numpy.array([ numpy.linalg.norm(coord) for coord in coordinates ])
+    distances = numpy.array([ numpy.linalg.norm(coord - origin) for coord in coordinates ])
 
     # Setup the data to sort.
     to_sort = numpy.array([ (c[0],c[1],c[2],d,t1,t2,cs) for (c,d,t1,t2,cs) in zip(coordinates,distances,types1, types2, co_sort)],

--- a/python/unittest/KMCLibTest/Utilities/CoordinateUtilitiesTest.py
+++ b/python/unittest/KMCLibTest/Utilities/CoordinateUtilitiesTest.py
@@ -24,22 +24,56 @@ class CoordinateUtilitiesTest(unittest.TestCase):
     def testSortCoordinatesDistance(self):
         """ Test the coordinate sorting wrt distances function. """
         # Lets, use these coordinates.
-        coords = numpy.array([[2.0,1.0,0.0],[1.0,2.0,0.0],[0.0,0.0,0.0],[-8.9,12.0,4.0]])
-        types  = ["B","A","C","A"]
+        coords = numpy.array([[2.0, 3.0, 0.0], [1.0, 2.0, 0.0],
+                              [0.0, 0.0, 0.0], [-8.9, 12.0, 4.0]])
+        types1 = ["B", "A", "C", "A"]
+        types2 = ["D", "G", "C", "V"]
+
+        # -----------------------------------------------------------------------------
+        # Let the 3rd coordinates be the center.
         center = 2
 
-        # Sort - wrt distance,type,x,y,z
-        (sorted_coords, sorted_distances, sorted_types, co_sorted_types) = sortCoordinatesDistance(coords, center, types)
+        # Sort wrt distance, type, x, y, z
+        sorted_coords, sorted_distances, sorted_types1, sorted_types2 = \
+            sortCoordinatesDistance(coords, center, types1, types2)
 
-        # Setup references.
-        ref_coords = numpy.array([[0.0,0.0,0.0],[1.0,2.0,0.0],[2.0,1.0,0.0],[-8.9,12.0,4.0]])
-        ref_types = ["C","A","B","A"]
-        ref_distances=numpy.array([numpy.linalg.norm(c) for c in ref_coords])
+        # Setup reference.
+        ref_coords = numpy.array([[0.0, 0.0, 0.0],
+                                  [1.0, 2.0, 0.0],
+                                  [2.0, 3.0, 0.0],
+                                  [-8.9, 12.0, 4.0]])
+        ref_types1 = ["C", "A", "B", "A"]
+        ref_types2 = ["C", "G", "D", "V"]
+        ref_distances = [0.0, 2.2360679774997898, 3.6055512754639891, 15.46641522784126]
 
         # Check.
-        self.assertAlmostEqual(numpy.linalg.norm(sorted_distances-ref_distances), 0.0, 10)
-        self.assertAlmostEqual(numpy.linalg.norm(sorted_coords-ref_coords), 0.0, 10)
-        self.assertEqual(sorted_types, ref_types)
+        self.assertTrue(numpy.allclose(sorted_coords, ref_coords))
+        self.assertTrue(numpy.allclose(sorted_distances, ref_distances))
+        self.assertListEqual(sorted_types1, ref_types1)
+        self.assertListEqual(sorted_types2, ref_types2)
+
+        # -----------------------------------------------------------------------------
+        # Let the 1st coordinates be the center.
+        center = 0
+
+        # Sort wrt distance, type, x, y, z
+        sorted_coords, sorted_distances, sorted_types1, sorted_types2 = \
+            sortCoordinatesDistance(coords, center, types1, types2)
+
+        # Setup reference.
+        ref_coords = numpy.array([[2.0, 3.0, 0.0],
+                                  [1.0, 2.0, 0.0],
+                                  [0.0, 0.0, 0.0],
+                                  [-8.9, 12.0, 4.0]])
+        ref_types1 = ["B", "A", "C", "A"]
+        ref_types2 = ["D", "G", "C", "V"]
+        ref_distances = [0.0, 1.4142135623730951, 3.6055512754639891, 14.690473103341498]
+
+        # Check.
+        self.assertTrue(numpy.allclose(sorted_coords, ref_coords))
+        self.assertTrue(numpy.allclose(sorted_distances, ref_distances))
+        self.assertListEqual(sorted_types1, ref_types1)
+        self.assertListEqual(sorted_types2, ref_types2)
 
     def testSortCoordinates(self):
         """ Test the coordinate sorting function. """


### PR DESCRIPTION
Dear Leetmaa,

I found that you may forget to substract the origin coordinate from all the other coordinates which are to be sorted. 
So I fixed it and add additional test for this utility function. :)

Shao Zhengjiang