### PR TITLE
Fix bug in re-matching of affected indices.

### DIFF
--- a/c++/src/latticemodel.cpp
+++ b/c++/src/latticemodel.cpp
@@ -87,7 +87,7 @@ void LatticeModel::singleStep()
 
     // Run the re-matching of the affected sites and their neighbours.
     const std::vector<int> & indices = \
-        lattice_map_.supersetNeighbourIndices(process.affectedIndices(), process.range());
+        lattice_map_.supersetNeighbourIndices(process.affectedIndices(), interactions_.maxRange());
 
     matcher_.calculateMatching(interactions_,
                                configuration_,


### PR DESCRIPTION
Hi leetmaa,
I think it is proper to use the max range of all processes instead of that of picked process to get the superset indices which would be rematched.

Because the ranges of processes may be different, if the short process performed and the range of that process is used, then the superset would miss the sites which is listed in processes with longer range.

In the picture below, the site red arrow pointing to is picked and performed a process with range(black circle), but it will miss the site blue arrows pointing to which is listed in another process with longer range(blue circle), the sites info in that "longer" process cannot be updated correcly.

![affected_indices](https://cloud.githubusercontent.com/assets/8553710/16564273/2b612fe0-4239-11e6-8ec2-147723339050.png)


Thanks, 
Shao Zhengjiang.