### PR TITLE
Add -fkeep-inline-function compiler option.

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -52,7 +52,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
   message( STATUS "Using the Intel compiler" )
   set( USING_INTEL TRUE )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-Bsymbolic -O3 -fPIC -Wall -Wextra -Werror -pedantic -std=c++0x")
-  set( CMAKE_CXX_FLAGS_DEBUG "-g -pg" )
+  set( CMAKE_CXX_FLAGS_DEBUG "-g -pg -fkeep-inline-functions" )
   set( CMAKE_CXX_FLAGS_RELEASE  "" )
   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO  "-g -pg" )
 
@@ -64,7 +64,7 @@ elseif (CMAKE_COMPILER_IS_GNUCXX)
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-Bsymbolic -O3 -ffast-math -fPIC -Wall -Wextra -Werror -pedantic -std=c++0x")
   endif()
 
-  set( CMAKE_CXX_FLAGS_DEBUG "-g -pg" )
+  set( CMAKE_CXX_FLAGS_DEBUG "-g -pg -fkeep-inline-functions" )
   set( CMAKE_CXX_FLAGS_RELEASE  "" )
   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO  "" )
 
@@ -82,7 +82,7 @@ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   message( STATUS "Using compiler ${CMAKE_CXX_COMPILER_ID}")
 
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fPIC -Wall -Wextra -Werror -pedantic -stdlib=libc++  -std=c++11")
-  set( CMAKE_CXX_FLAGS_DEBUG "-g -pg" )
+  set( CMAKE_CXX_FLAGS_DEBUG "-g -pg -fkeep-inline-functions" )
   set( CMAKE_CXX_FLAGS_RELEASE  "" )
   set( CMAKE_CXX_FLAGS_RELWITHDEBINFO  "" )
 


### PR DESCRIPTION
Hi, leetma:

I think it is better to add -fkeep-inline-function compiler option to generate a callable
version of inline functions for debug inline functions with gdb, or it will keep showing `Cannot evaluate function -- may be inlined` when debugging inline functions like printing some variables with inlined query functions.

referenc:
http://stackoverflow.com/questions/22029834/possible-to-call-inline-functions-in-gdb-and-or-emit-them-using-gcc

Thanks,
ShaoZhengjiang