### PR TITLE
Use C++ MPI interfaces instead of C interfaces.

### DIFF
--- a/c++/src/mpicommons.cpp
+++ b/c++/src/mpicommons.cpp
@@ -28,12 +28,8 @@ void MPICommons::init()
 
     // Switch for using MPI.
 #if RUNMPI == true
-    // Dummy args.
-    int argc = 0;
-    char** argv;
-
     // Make the init call.
-    MPI_Init( &argc, &argv );
+    MPI::Init();
 
     // Set the flag to prevent further calls.
     inited__ = true;
@@ -51,19 +47,19 @@ void MPICommons::finalize()
     }
 
 #if RUNMPI == true
-        MPI_Finalize();
-        finalized__ = true;
+    MPI::Finalize();
+    finalized__ = true;
 #endif
 }
 
 
 // -----------------------------------------------------------------------------
 //
-int MPICommons::myRank(const MPI_Comm comm)
+int MPICommons::myRank(const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
     int rank;
-    MPI_Comm_rank( comm, &rank );
+    rank = comm.Get_rank();
     return rank;
 #else
     return 0;
@@ -73,11 +69,11 @@ int MPICommons::myRank(const MPI_Comm comm)
 
 // -----------------------------------------------------------------------------
 //
-int MPICommons::size(const MPI_Comm comm)
+int MPICommons::size(const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
     int size;
-    MPI_Comm_size( comm, &size );
+    size = comm.Get_size();
     return size;
 #else
     return 1;
@@ -87,9 +83,10 @@ int MPICommons::size(const MPI_Comm comm)
 
 // -----------------------------------------------------------------------------
 //
-void MPICommons::barrier(const MPI_Comm comm)
+void MPICommons::barrier(const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
-    MPI_Barrier( comm );
+    comm.Barrier();
 #endif
 }
+

--- a/c++/src/mpicommons.h
+++ b/c++/src/mpicommons.h
@@ -32,22 +32,23 @@ struct MPICommons {
      *  \param comm: The communicator to use.
      *  \return: The rank of this process withing the given communicator.
      */
-    static int myRank(const MPI_Comm comm=MPI_COMM_WORLD);
+    static int myRank(const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
     /*! \brief Wrapps MPI_COMM_SIZE
      *  \param comm: The communicator to use.
      *  \return: The sise of the communicator (the total number of processes).
      */
-    static int size(const MPI_Comm comm=MPI_COMM_WORLD);
+    static int size(const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
     /*! \brief Wrapps MPI_BARRIER, syncronizing processes.
      *  \param comm: The communicator to use.
      */
-    static void barrier(const MPI_Comm comm=MPI_COMM_WORLD);
+    static void barrier(const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
     /*! \brief Returns true if the calling process is the master.
      */
-    static bool isMaster(const MPI_Comm comm=MPI_COMM_WORLD) { return (myRank(comm) == 0); }
+    static bool isMaster(const MPI::Intracomm & comm=MPI::COMM_WORLD)
+    { return (myRank(comm) == 0); }
 
 
 

--- a/c++/src/mpih.h
+++ b/c++/src/mpih.h
@@ -23,8 +23,11 @@
 #if RUNMPI == true
 #include <mpi.h>
 #else
-typedef int MPI_Comm;
-#define MPI_COMM_WORLD 91
+namespace MPI
+{
+    typedef int Interacomm;
+    static int COMM_WORLD;
+}
 #endif
 
 #endif // __MPIH__

--- a/c++/src/mpiroutines.cpp
+++ b/c++/src/mpiroutines.cpp
@@ -17,7 +17,7 @@
 // -------------------------------------------------------------------------- //
 //
 void distributeToAll(int & data,
-                     const MPI_Comm & comm)
+                     const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
 
@@ -28,11 +28,10 @@ void distributeToAll(int & data,
     const int root = 0;
 
     // Send and recieve.
-    MPI_Bcast(&data,         // The send and recieve buffer.
-              size,          // The number of elements to communicate.
-              MPI_INT,       // The type of data.
-              root,          // The sender (master).
-              comm);         // The communicator we use.
+    comm.Bcast(&data,         // The send and recieve buffer.
+               size,          // The number of elements to communicate.
+               MPI_INT,       // The type of data.
+               root);         // The sender (master).
 
     // Done.
 #endif
@@ -42,7 +41,7 @@ void distributeToAll(int & data,
 // -------------------------------------------------------------------------- //
 //
 void sumOverProcesses(int & data,
-                      const MPI_Comm & comm)
+                      const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
     const int size = 1;
@@ -50,12 +49,11 @@ void sumOverProcesses(int & data,
     // Copy the data over to the send buffer.
     int send = data;
 
-    MPI_Allreduce(&send,       // Send buffer.
-                  &data,       // Recieve buffer (overwrite)
-                  size,        // Size of the buffers.
-                  MPI_INT,     // Data type.
-                  MPI_SUM,     // Operation to perform.
-                  comm);       // The communicator.
+    comm.Allreduce(&send,       // Send buffer.
+                   &data,       // Recieve buffer (overwrite)
+                   size,        // Size of the buffers.
+                   MPI_INT,     // Data type.
+                   MPI_SUM);    // Operation to perform.
     // Done.
 #endif
 }
@@ -63,7 +61,7 @@ void sumOverProcesses(int & data,
 // -------------------------------------------------------------------------- //
 //
 void sumOverProcesses(std::vector<int> & data,
-                      const MPI_Comm & comm)
+                      const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
     const int size = data.size();
@@ -71,12 +69,11 @@ void sumOverProcesses(std::vector<int> & data,
     // Copy the data over to the send buffer.
     std::vector<int> send(data);
 
-    MPI_Allreduce(&send[0],    // Send buffer.
-                  &data[0],    // Recieve buffer (overwrite)
-                  size,        // Size of the buffers.
-                  MPI_INT,     // Data type.
-                  MPI_SUM,     // Operation to perform.
-                  comm);       // The communicator.
+    comm.Allreduce(&send[0],    // Send buffer.
+                   &data[0],    // Recieve buffer (overwrite)
+                   size,        // Size of the buffers.
+                   MPI_INT,     // Data type.
+                   MPI_SUM);    // Operation to perform.
     // Done.
 #endif
 }
@@ -85,7 +82,7 @@ void sumOverProcesses(std::vector<int> & data,
 // -------------------------------------------------------------------------- //
 //
 void sumOverProcesses(std::vector<double> & data,
-                      const MPI_Comm & comm)
+                      const MPI::Intracomm & comm)
 {
 #if RUNMPI == true
     const int size = data.size();
@@ -93,12 +90,11 @@ void sumOverProcesses(std::vector<double> & data,
     // Copy the data over to the send buffer.
     std::vector<double> send(data);
 
-    MPI_Allreduce(&send[0],    // Send buffer.
-                  &data[0],    // Recieve buffer (overwrite)
-                  size,        // Size of the buffers.
-                  MPI_DOUBLE,  // Data type.
-                  MPI_SUM,     // Operation to perform.
-                  comm);       // The communicator.
+    comm.Allreduce(&send[0],    // Send buffer.
+                   &data[0],    // Recieve buffer (overwrite)
+                   size,        // Size of the buffers.
+                   MPI_DOUBLE,  // Data type.
+                   MPI_SUM);    // Operation to perform.
     // Done.
 #endif
 }

--- a/c++/src/mpiroutines.h
+++ b/c++/src/mpiroutines.h
@@ -33,7 +33,7 @@ std::vector< std::pair<int,int> > determineChunks(const int mpi_size,
  *  \param comm : The communicator to use.
  */
 void distributeToAll(int & data,
-                     const MPI_Comm & comm=MPI_COMM_WORLD);
+                     const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
 
 /*! \brief Sum the data over all processors.
@@ -41,7 +41,7 @@ void distributeToAll(int & data,
  *  \param comm : The communicator to use.
  */
 void sumOverProcesses(int & data,
-                      const MPI_Comm & comm=MPI_COMM_WORLD);
+                      const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
 
 /*! \brief Sum the data over all processors.
@@ -49,7 +49,7 @@ void sumOverProcesses(int & data,
  *  \param comm : The communicator to use.
  */
 void sumOverProcesses(std::vector<int> & data,
-                      const MPI_Comm & comm=MPI_COMM_WORLD);
+                      const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
 
 /*! \brief Sum the data over all processors.
@@ -57,7 +57,7 @@ void sumOverProcesses(std::vector<int> & data,
  *  \param comm : The communicator to use.
  */
 void sumOverProcesses(std::vector<double> & data,
-                      const MPI_Comm & comm=MPI_COMM_WORLD);
+                      const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
 
 /*! \brief Split the global vector over the processes.
@@ -67,7 +67,7 @@ void sumOverProcesses(std::vector<double> & data,
  */
 template <class T_vector>
 T_vector splitOverProcesses(const T_vector & global,
-                            const MPI_Comm & comm=MPI_COMM_WORLD);
+                            const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
 /*! \brief Join the local vectors to form a global.
  *  \param local  : The data vector to join.
@@ -76,7 +76,7 @@ T_vector splitOverProcesses(const T_vector & global,
  */
 template <class T_vector>
 T_vector joinOverProcesses(const T_vector & local,
-                           const MPI_Comm & comm=MPI_COMM_WORLD);
+                           const MPI::Intracomm & comm=MPI::COMM_WORLD);
 
 
 
@@ -89,13 +89,13 @@ T_vector joinOverProcesses(const T_vector & local,
 //
 template <class T_vector>
 T_vector splitOverProcesses(const T_vector & global,
-                            const MPI_Comm & comm)
+                            const MPI::Intracomm & comm)
 {
     // Get the dimensions.
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( comm, &rank );
-    MPI_Comm_size( comm, &size );
+    rank = comm.Get_rank();
+    size = comm.Get_size();
 #else
     int rank = 0;
     int size = 1;
@@ -128,7 +128,7 @@ T_vector splitOverProcesses(const T_vector & global,
 //
 template <class T_vector>
 T_vector joinOverProcesses(const T_vector & local,
-                           const MPI_Comm & comm)
+                           const MPI::Intracomm & comm)
 {
     // PERFORMME: Prototyping. Chunks does not need to be this involved.
 
@@ -175,3 +175,4 @@ T_vector joinOverProcesses(const T_vector & local,
 
 
 #endif // __MPIROUTINES__
+

--- a/c++/unittest/test_mpicommons.cpp
+++ b/c++/unittest/test_mpicommons.cpp
@@ -22,7 +22,7 @@ void Test_MPICommons::testSize()
     // Get the reference size.
 #if RUNMPI == true
     int ref_size;
-    MPI_Comm_size( MPI_COMM_WORLD, &ref_size );
+    ref_size = MPI::COMM_WORLD.Get_size();
 #else
     const int ref_size = 1;
 #endif
@@ -42,7 +42,7 @@ void Test_MPICommons::testRank()
     // Get the reference rank.
 #if RUNMPI == true
     int ref_rank;
-    MPI_Comm_rank( MPI_COMM_WORLD, &ref_rank );
+    ref_rank = MPI::COMM_WORLD.Get_rank();
 #else
     const int ref_rank = 0;
 #endif
@@ -62,7 +62,7 @@ void Test_MPICommons::testIsMaster()
     // Get the reference rank.
 #if RUNMPI == true
     int ref_rank;
-    MPI_Comm_rank( MPI_COMM_WORLD, &ref_rank );
+    ref_rank = MPI::COMM_WORLD.Get_rank();
 #else
     const int ref_rank = 0;
 #endif
@@ -88,9 +88,8 @@ void Test_MPICommons::testBarrier()
 // Only if run in parallel.
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-    MPI_Comm_size( MPI_COMM_WORLD, &size );
-
+    rank = MPI::COMM_WORLD.Get_rank();
+    size = MPI::COMM_WORLD.Get_size();
     time_t seconds;
 
     std::vector<int> time_before_sleep(size);
@@ -120,28 +119,25 @@ void Test_MPICommons::testBarrier()
 
     // Communicate the timing results.
     std::vector<int> send1(time_before_sleep);
-    MPI_Allreduce(&send1[0],
-                  &time_before_sleep[0],
-                  size,
-                  MPI_INT,
-                  MPI_SUM,
-                  MPI_COMM_WORLD);
+    MPI::COMM_WORLD.Allreduce(&send1[0],
+                              &time_before_sleep[0],
+                              size,
+                              MPI_INT,
+                              MPI_SUM);
 
     std::vector<int> send2(time_after_sleep);
-    MPI_Allreduce(&send2[0],
-                  &time_after_sleep[0],
-                  size,
-                  MPI_INT,
-                  MPI_SUM,
-                  MPI_COMM_WORLD);
+    MPI::COMM_WORLD.Allreduce(&send2[0],
+                              &time_after_sleep[0],
+                              size,
+                              MPI_INT,
+                              MPI_SUM);
 
     std::vector<int> send3(time_after_barrier);
-    MPI_Allreduce(&send3[0],
-                  &time_after_barrier[0],
-                  size,
-                  MPI_INT,
-                  MPI_SUM,
-                  MPI_COMM_WORLD);
+    MPI::COMM_WORLD.Allreduce(&send3[0],
+                              &time_after_barrier[0],
+                              size,
+                              MPI_INT,
+                              MPI_SUM);
 
     // Check that the results.
 

--- a/c++/unittest/test_mpiroutines.cpp
+++ b/c++/unittest/test_mpiroutines.cpp
@@ -101,7 +101,7 @@ void Test_MPIRoutines::testDistributeToAll()
 {
 #if RUNMPI == true
     int rank;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+    rank = MPI::COMM_WORLD.Get_rank();
 #else
     const int rank = 0;
 #endif
@@ -117,7 +117,7 @@ void Test_MPIRoutines::testDistributeToAll()
     }
 
     // Send to all other nodes.
-    distributeToAll(data, MPI_COMM_WORLD);
+    distributeToAll(data, MPI::COMM_WORLD);
 
     // Check.
     CPPUNIT_ASSERT_EQUAL( data, reference );
@@ -131,8 +131,8 @@ void Test_MPIRoutines::testSumOverProcessesInt()
 {
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-    MPI_Comm_size( MPI_COMM_WORLD, &size );
+    rank = MPI::COMM_WORLD.Get_rank();
+    size = MPI::COMM_WORLD.Get_size();
 #else
     const int rank = 0;
     const int size = 1;
@@ -141,7 +141,7 @@ void Test_MPIRoutines::testSumOverProcessesInt()
     int sum_value = rank*rank + 3;
 
     // Sum.
-    sumOverProcesses(sum_value, MPI_COMM_WORLD);
+    sumOverProcesses(sum_value, MPI::COMM_WORLD);
 
     // Calculate the reference.
     int ref_sum = 0;
@@ -162,8 +162,8 @@ void Test_MPIRoutines::testSumOverProcessesVectorInt()
 {
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-    MPI_Comm_size( MPI_COMM_WORLD, &size );
+    rank = MPI::COMM_WORLD.Get_rank();
+    size = MPI::COMM_WORLD.Get_size();
 #else
     const int rank = 0;
     const int size = 1;
@@ -173,7 +173,7 @@ void Test_MPIRoutines::testSumOverProcessesVectorInt()
     data[rank] = 0;
 
     // Sum.
-    sumOverProcesses(data, MPI_COMM_WORLD);
+    sumOverProcesses(data, MPI::COMM_WORLD);
 
     // Calculate the reference.
     std::vector<int> ref_data(size, 0);
@@ -202,8 +202,8 @@ void Test_MPIRoutines::testSumOverProcessesVectorDouble()
 {
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-    MPI_Comm_size( MPI_COMM_WORLD, &size );
+    rank = MPI::COMM_WORLD.Get_rank();
+    size = MPI::COMM_WORLD.Get_size();
 #else
     const int rank = 0;
     const int size = 1;
@@ -213,7 +213,7 @@ void Test_MPIRoutines::testSumOverProcessesVectorDouble()
     data[rank] = 0.0;
 
     // Sum.
-    sumOverProcesses(data, MPI_COMM_WORLD);
+    sumOverProcesses(data, MPI::COMM_WORLD);
 
     // Calculate the reference.
     std::vector<double> ref_data(size, 0.0);
@@ -242,8 +242,8 @@ void Test_MPIRoutines::testSplitOverProcesses()
 {
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-    MPI_Comm_size( MPI_COMM_WORLD, &size );
+    rank = MPI::COMM_WORLD.Get_rank();
+    size = MPI::COMM_WORLD.Get_size();
 #else
     const int rank = 0;
     const int size = 1;
@@ -258,7 +258,7 @@ void Test_MPIRoutines::testSplitOverProcesses()
     }
 
     // Split.
-    std::vector<int> local_data = splitOverProcesses(global_data, MPI_COMM_WORLD);
+    std::vector<int> local_data = splitOverProcesses(global_data, MPI::COMM_WORLD);
 
     // Check.
     if (rank == size - 1)
@@ -286,8 +286,8 @@ void Test_MPIRoutines::testJoinOverProcesses()
 {
 #if RUNMPI == true
     int rank, size;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-    MPI_Comm_size( MPI_COMM_WORLD, &size );
+    rank = MPI::COMM_WORLD.Get_rank();
+    size = MPI::COMM_WORLD.Get_size();
 #else
     const int rank = 0;
     const int size = 1;
@@ -302,7 +302,7 @@ void Test_MPIRoutines::testJoinOverProcesses()
     }
 
     // Split.
-    std::vector<int> local_data = splitOverProcesses(global_data, MPI_COMM_WORLD);
+    std::vector<int> local_data = splitOverProcesses(global_data, MPI::COMM_WORLD);
 
     // Multiply the local data with the rank.
     for (size_t i = 0; i < local_data.size(); ++i)
@@ -311,7 +311,7 @@ void Test_MPIRoutines::testJoinOverProcesses()
     }
 
     // Join.
-    std::vector<int> new_global = joinOverProcesses(local_data, MPI_COMM_WORLD);
+    std::vector<int> new_global = joinOverProcesses(local_data, MPI::COMM_WORLD);
 
     // Create a reference new global.
     std::vector<int> new_global_ref(global_data);


### PR DESCRIPTION
Hi,

I tried to change the use of interfaces of MPI from C to C++. It will make the coding style more uniform and helps to remove the dummy arguments like `int argc` and `char** argv` etc. :)

Shao Zhengjiang