### PR TITLE
Change datatype from unsigned long int to uint64_t

### DIFF
--- a/c++/src/hash.cpp
+++ b/c++/src/hash.cpp
@@ -20,14 +20,15 @@
 
 #include <cstdio>
 #include <cstring>
+#include <cinttypes>
 
 
 // -------------------------------------------------------------------------- //
 //
-unsigned long int hash64MD5xor(std::vector<int> & message)
+uint64_t hash64MD5xor(std::vector<int> & message)
 {
     // Get the full hash.
-    unsigned long int res[2];
+    uint64_t res[2];
     void *ptr1 = (&message[0]);
 
     // Call the md5 core.
@@ -41,9 +42,9 @@ unsigned long int hash64MD5xor(std::vector<int> & message)
 // -------------------------------------------------------------------------- //
 //
 void md5Core(void *message,
-             const unsigned long int size,
-             unsigned long int & result1,
-             unsigned long int & result2)
+             const uint64_t size,
+             uint64_t & result1,
+             uint64_t & result2)
 {
     // Call the external MD5 routine.
     MD5_CTX ctx;
@@ -53,7 +54,7 @@ void md5Core(void *message,
     MD5_Final(result, &ctx);
 
     // Get the digest in the right format and return.
-    unsigned long int res[2];
+    uint64_t res[2];
     memcpy(res, result, 16);
     result1 = res[0];
     result2 = res[1];
@@ -67,12 +68,12 @@ void md5Core(void *message,
 std::string hashMD5(const std::string & message)
 {
     // Get the full hash.
-    unsigned long int res[2];
+    uint64_t res[2];
     hashMD5(message, res[0], res[1]);
 
     // Get the digest in the right format and return.
     char final[33];
-    sprintf(final, "%lx%lx", res[0], res[1]);
+    sprintf(final, "%" PRIx64 "%" PRIx64, res[0], res[1]);
     return std::string(final);
 }
 
@@ -80,8 +81,8 @@ std::string hashMD5(const std::string & message)
 // -------------------------------------------------------------------------- //
 //
 void hashMD5(const std::string & message,
-             unsigned long int & result1,
-             unsigned long int & result2)
+             uint64_t & result1,
+             uint64_t & result2)
 {
     // Copy the incomming message to avoid an evil const cast.
     std::string msg(message);
@@ -98,10 +99,10 @@ void hashMD5(const std::string & message,
 
 // -------------------------------------------------------------------------- //
 //
-unsigned long int hash64MD5xor(const std::string & message)
+uint64_t hash64MD5xor(const std::string & message)
 {
     // Get the full hash.
-    unsigned long int res[2];
+    uint64_t res[2];
     hashMD5(message, res[0], res[1]);
 
     // XOR down to 64-bit result.
@@ -111,7 +112,7 @@ unsigned long int hash64MD5xor(const std::string & message)
 
 // -------------------------------------------------------------------------- //
 //
-unsigned long int hashCustomRateInput(const int index,
+uint64_t hashCustomRateInput(const int index,
                                       const Process & process,
                                       const Configuration & configuration)
 {

--- a/c++/src/hash.h
+++ b/c++/src/hash.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include <cstdint>
+
 // Forward declarations.
 class Process;
 class Configuration;
@@ -35,7 +37,7 @@ std::string hashMD5(const std::string & message);
  *  \param message : The message to hash.
  *  \returns : The 64-bit 'MD5' digest of the message.
  */
-unsigned long int hash64MD5xor(const std::string & message);
+uint64_t hash64MD5xor(const std::string & message);
 
 
 /*! \brief Function for generating the MD5 hash as an xor-ed
@@ -43,7 +45,7 @@ unsigned long int hash64MD5xor(const std::string & message);
  *  \param message : The message to hash.
  *  \returns : The 64-bit 'MD5' digest of the message.
  */
-unsigned long int hash64MD5xor(std::vector<int> & message);
+uint64_t hash64MD5xor(std::vector<int> & message);
 
 
 /*! \brief Function for generating the MD5 hash as two 64-bit integers.
@@ -52,8 +54,8 @@ unsigned long int hash64MD5xor(std::vector<int> & message);
  *  \param result2 (out) : The last 64-bits of the hash.
  */
 void hashMD5(const std::string & message,
-             unsigned long int & result1,
-             unsigned long int & result2);
+             uint64_t & result1,
+             uint64_t & result2);
 
 
 /*! \brief Core md5 work horse. The only place we call the external
@@ -64,9 +66,9 @@ void hashMD5(const std::string & message,
  *  \param result2 (out) : The last 64-bits of the digest.
  */
 void md5Core(void *message,
-             const unsigned long int size,
-             unsigned long int & result1,
-             unsigned long int & result2);
+             const uint64_t size,
+             uint64_t & result1,
+             uint64_t & result2);
 
 
 /*! \brief Function for generating a 64-bit hash from the input to the
@@ -76,7 +78,7 @@ void md5Core(void *message,
  *  \param configuration : The global configuration of the system.
  *  \returns: 64-bit hash value.
  */
-unsigned long int hashCustomRateInput(const int index,
+uint64_t hashCustomRateInput(const int index,
                                       const Process & process,
                                       const Configuration & configurartion);
 

--- a/c++/unittest/test_hash.cpp
+++ b/c++/unittest/test_hash.cpp
@@ -17,6 +17,9 @@
 #include "latticemap.h"
 #include "random.h"
 
+#include <cstdint>
+#include <cinttypes>
+
 
 // For profiling on Linux.
 #include <sys/time.h>
@@ -53,10 +56,10 @@ void Test_Hash::test64MD5String()
 {
     {
         // Get the 64-bit xor-ed hash.
-        size_t hash = hash64MD5xor("");
+        uint64_t hash = hash64MD5xor("");
 
         // Get the full hash.
-        size_t hash1, hash2;
+        uint64_t hash1, hash2;
         hashMD5("", hash1, hash2);
 
         // Check that this is the xor-ed parts of the full md5 hash.
@@ -66,10 +69,10 @@ void Test_Hash::test64MD5String()
 
     {
         // Get the 64-bit xor-ed hash.
-        size_t hash = hash64MD5xor("This is another string.");
+        uint64_t hash = hash64MD5xor("This is another string.");
 
         // Get the full hash.
-        size_t hash1, hash2;
+        uint64_t hash1, hash2;
         hashMD5("This is another string.", hash1, hash2);
 
         // Check that this is the xor-ed parts of the full md5 hash.
@@ -154,27 +157,27 @@ void Test_Hash::testHashCustomRateInput()
     {
         // Get the hash.
         index = 1;
-        const unsigned long int hash1 = hashCustomRateInput(index, process1, config);
-        const unsigned long int ref1 = 18009609292013583759u;
+        const uint64_t hash1 = hashCustomRateInput(index, process1, config);
+        const uint64_t ref1 = 18009609292013583759u;
         CPPUNIT_ASSERT_EQUAL(hash1, ref1);
 
         // Get the hash.
         index = 0;
-        const unsigned long int hash0 = hashCustomRateInput(index, process1, config);
-        const unsigned long int ref0 = 4224368175550234772u;
+        const uint64_t hash0 = hashCustomRateInput(index, process1, config);
+        const uint64_t ref0 = 4224368175550234772u;
         CPPUNIT_ASSERT_EQUAL(hash0, ref0);
     }
 
     {
         // Check against another process that differs in the process number.
         index = 1;
-        const unsigned long int hash1 = hashCustomRateInput(index, process2, config);
-        const unsigned long int ref1 = 4824710481459367137u;
+        const uint64_t hash1 = hashCustomRateInput(index, process2, config);
+        const uint64_t ref1 = 4824710481459367137u;
         CPPUNIT_ASSERT_EQUAL(hash1, ref1);
 
         index = 0;
-        const unsigned long int hash0 = hashCustomRateInput(index, process2, config);
-        const unsigned long int ref0 = 17780468236463825071u;
+        const uint64_t hash0 = hashCustomRateInput(index, process2, config);
+        const uint64_t ref0 = 17780468236463825071u;
         CPPUNIT_ASSERT_EQUAL(hash0, ref0);
     }
 
@@ -182,7 +185,7 @@ void Test_Hash::testHashCustomRateInput()
     if (false)
     {
         double t1 = cpu_time();
-        unsigned long int hash_loop;
+        uint64_t hash_loop;
         for (int i = 0; i < 10000000; ++i)
         {
             hash_loop = hashCustomRateInput(index, process2, config);
@@ -190,6 +193,6 @@ void Test_Hash::testHashCustomRateInput()
         double t2 = cpu_time();
 
         // Printout to avoid optimization.
-        printf("hash0 %lx\n %e", hash_loop, (t2-t1)/10000000);
+        printf("hash0 %" PRIx64 "\n %e", hash_loop, (t2-t1)/10000000);
     }
 }


### PR DESCRIPTION
Using the fixed-size datatype from stdint.h instead of unsigned long int
in hash related functions for platform portability.