### PR TITLE
Modify C++ time propagator

### DIFF
--- a/c++/src/simulationtimer.cpp
+++ b/c++/src/simulationtimer.cpp
@@ -29,9 +29,12 @@ void SimulationTimer::propagateTime(const double total_rate)
 {
     // Propagate the time of the system.
     double rnd;
+    double dt;
     do
-        double rnd = randomDouble01();
-    while (rnd < 1e-323);
-    const double dt  = -std::log(rnd)/total_rate;
+    {
+        rnd = randomDouble01();
+        dt  = -std::log(rnd)/total_rate;
+    }
+    while (std::isinf(dt));
     simulation_time_ += dt;
 }

--- a/c++/src/simulationtimer.cpp
+++ b/c++/src/simulationtimer.cpp
@@ -28,7 +28,10 @@ SimulationTimer::SimulationTimer() :
 void SimulationTimer::propagateTime(const double total_rate)
 {
     // Propagate the time of the system.
-    const double rnd = randomDouble01();
+    double rnd;
+    do
+        double rnd = randomDouble01();
+    while (rnd < 1e-323);
     const double dt  = -std::log(rnd)/total_rate;
     simulation_time_ += dt;
 }


### PR DESCRIPTION
When I use the program, sometimes I'll get "inf" for simulation time. I guess this may be caused by the random number generated.
Therefore, I use a loop in SimulationTimer::propagateTime function to avoid a random number of zero, which may cause the time being infinity.
Hope this may help.