### PR TITLE
Correct cmake instructions in install.html

### DIFF
--- a/manual/install.html
+++ b/manual/install.html
@@ -158,10 +158,10 @@ The current version of <tt class="xref py py-mod docutils literal"><span class="
 <h2>Make system<a class="headerlink" href="#make-system" title="Permalink to this headline">¶</a></h2>
 <p>The make system is based on <strong>CMake</strong>. Installing <strong>CMake</strong>
 can be done by typing on Ubuntu:</p>
-<div class="highlight-python"><pre>sudo apt-get install swig</pre>
+<div class="highlight-python"><pre>sudo apt-get install cmake</pre>
 </div>
-<p>and on Mac OSX using macports:</p>
-<div class="highlight-python"><pre>sudo port install swig &amp;&amp; sudo port install swig-python</pre>
+<p>and on Mac OSX using homebrew:</p>
+<div class="highlight-python"><pre>brew install cmake</pre>
 </div>
 </div>
 <div class="section" id="swig">


### PR DESCRIPTION
cmake install instructions were incorrect (actually for SWIG); now updated for cmake (Ubuntu and macOS)